### PR TITLE
fix: Align button on main, remove sort button from single view

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -6,7 +6,6 @@ import { fetchData } from '../apiCalls';
 import MainMovies from '../Movies/MainMovies/MainMovies';
 import SingleMovie from '../Movies/SingleMovie/SingleMovie';
 import Footer from '../Footer/Footer';
-import SortButton from '../Header/SortButton/SortButton';
 
 
 class App extends React.Component {
@@ -52,18 +51,14 @@ class App extends React.Component {
     return (
       <main className="App">
         <Header resetMainPage={this.resetMainPage} />
-        <SortButton sortByRating={this.sortByRating} />
-        <Switch>
-          <Route exact path="/" render={() => (
-            <MainMovies posters={posters}  />
-          )} />
-          <Route path="/:id" render={({ match }) => (
-            <SingleMovie
-              match={match}
-            />
-          )} />
-          <Route path="*" render={() => <h2>Error: Page not found</h2>} />
-        </Switch>
+        <body>
+          <Switch>
+            <Route exact path="/" render={() => (
+              <MainMovies posters={posters} sortByRating={this.sortByRating}/> )} />
+            <Route path="/:id" render={({ match }) => ( <SingleMovie match={match} />)} />
+            <Route path="*" render={() => <h2>Error: Page not found</h2>} />
+          </Switch>
+        </body>
         <Footer />
       </main>
     );

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -1,6 +1,5 @@
 import React from "react";
-import logo from "./rancid-clear.png"
-import logo2 from "./rancid-logo-2.png"
+import logo2 from "./rancid-logo-2.png";
 import '../Header/Header.css';
 import { Link } from 'react-router-dom';
 

--- a/src/Header/SortButton/SortButton.css
+++ b/src/Header/SortButton/SortButton.css
@@ -1,4 +1,0 @@
-button {
-  width: 15px;
-  height: auto;
-}

--- a/src/Header/SortButton/SortButton.js
+++ b/src/Header/SortButton/SortButton.js
@@ -1,9 +1,0 @@
-import React from "react";
-// import "..SortButton/SortButton.css";
-
-
-const SortButton = ({ sortByRating }) => {
- return <button onClick={ sortByRating} >Sort by Rating</button>;
-}
-
-export default SortButton;

--- a/src/Movies/MainMovies/MainMovies.js
+++ b/src/Movies/MainMovies/MainMovies.js
@@ -3,9 +3,10 @@ import React from "react";
 import PropTypes from 'prop-types';
 import '../MainMovies/MainMovies.css';
 import Poster from "../../Poster/Poster";
+import SortButton from "./SortButton/SortButton"
 
 //Functions
-const MainMovies = ({ posters }) =>  {
+const MainMovies = ({ posters, sortByRating }) =>  {
   if(!posters) {
     return [];
   }
@@ -23,6 +24,7 @@ const posterCards = posters.movies.map(({ poster_path, id, title, average_rating
 });
     return (
       <div className="wrapper">
+        <SortButton sortByRating={sortByRating} />
         <div className="poster-container">
           {posterCards}
         </div>

--- a/src/Movies/MainMovies/SortButton/SortButton.css
+++ b/src/Movies/MainMovies/SortButton/SortButton.css
@@ -1,0 +1,10 @@
+.sort-button {
+  display: flex;
+  width: auto;
+  height: auto;
+  margin-left: 3.3rem;
+  padding: .5rem .6rem;
+  background: rgb(117, 54, 76);
+  font-size: .9rem;
+  color:rgb(244, 240, 233);
+}

--- a/src/Movies/MainMovies/SortButton/SortButton.js
+++ b/src/Movies/MainMovies/SortButton/SortButton.js
@@ -1,0 +1,9 @@
+import React from "react";
+import "./SortButton.css";
+
+
+const SortButton = ({ sortByRating }) => {
+ return <button className="sort-button" onClick={ sortByRating} >Sort by Rating</button>;
+}
+
+export default SortButton;

--- a/src/Poster/Poster.css
+++ b/src/Poster/Poster.css
@@ -7,3 +7,11 @@
 .poster-img:hover {
   box-shadow:  0 0 26px 5px rgb(140,131,3);
 }
+
+.rating {
+  color:rgb(237, 232, 226);
+  display: flex;
+  text-align: right;
+  padding-left: 1.6rem;
+  margin-top: 2px;
+}

--- a/src/Poster/Poster.js
+++ b/src/Poster/Poster.js
@@ -7,7 +7,7 @@ const Poster = ({ posterImg, rating, posterId, posterTitle }) => {
   return (
     <Link key={posterId} to={`/${posterId}`}>
     <img className="poster-img" src={posterImg} id={posterId} alt={posterTitle} />
-    <p>{rating}</p>
+    <p className="rating">Rating: {rating}</p>
   </Link>
   );
 };


### PR DESCRIPTION
## Checklist:

Checkmarks:

   - [] All Tests are Passing

Type of change

   - [] New feature
   - X] Bug Fix

Implements/Fixes:

    Removes the sort button from single view page
    Aligns the sort button better on main page
    uses responsive rems
    adds the word "Rating" before the number below each poster

Check the correct boxes

   - [] This broke nothing
   - [] This broke some stuff
   - [] This broke everything

Testing Changes

   - [] No Tests have been changed
   - [] Some Tests have been changed
   - [] All of the Tests have been changed(Please describe what in the world happened)

Checklist:

   - [] My code has no unused/commented out code
   - [] I have reviewed my code
   - [] I have commented my code, particularly in hard-to-understand areas
   - [] I have fully tested my code
   - [X] I have added one or more people as "Reviewers" to review & merge
   
   Notes: 
   Even though Rating: # isn't as pretty. We can use this for now. It is good UX as it lets users know what the number is below the poster. And it makes sense to let the users know what the rating is once they are sorted by ratings. 
   I haven't run any of the cypress or prop tests with these new changes, but will add that to my list for tomorrow. 

![image](https://github.com/CBradsen/rancid/assets/117617970/1bcd58df-592e-4f8a-b6d1-cc31492e13b7)
![image](https://github.com/CBradsen/rancid/assets/117617970/8a24a118-3e2a-4a63-92a4-783558f4dfb3)
